### PR TITLE
Add open() and close() file methods

### DIFF
--- a/benchmark/read_benchmark.cpp
+++ b/benchmark/read_benchmark.cpp
@@ -159,7 +159,7 @@ std::vector<std::uint8_t> read_iostream_range_prealloc(const char* file_name)
 // Incrementally reads from a file, with good error checking behind the scenes
 std::vector<std::uint8_t> read_modern_inc(const char* file_name)
 {
-    auto file = io::open_file(file_name);
+    auto file = io::open_file(file_name, io::open_mode::read_only);
     std::vector<uint8_t> output;
     io::read_all(file, io::dynamic_buffer(output));
     return output;
@@ -169,7 +169,7 @@ std::vector<std::uint8_t> read_modern_inc(const char* file_name)
 // Read a file into a preallocated vector with exceptions
 std::vector<std::uint8_t> read_modern_prealloc(const char* file_name)
 {
-    auto file = io::open_file(file_name);
+    auto file = io::open_file(file_name, io::open_mode::read_only);
     auto file_size = io::seek(file, 0, io::seek_mode::end);
     io::seek(file, 0, io::seek_mode::start);
     std::vector<std::uint8_t> output(file_size);
@@ -180,14 +180,14 @@ std::vector<std::uint8_t> read_modern_prealloc(const char* file_name)
 // Read a file into a vector using a stream reader (in two lines!)
 std::vector<std::uint8_t> read_modern_range(const char* file_name)
 {
-    auto file = io::open_file(file_name);
+    auto file = io::open_file(file_name, io::open_mode::read_only);
     return io::read(std::move(file));
 }
 
 // Read a file into a preallocated vector using a stream reader
 std::vector<std::uint8_t> read_modern_range_prealloc(const char* file_name)
 {
-    auto file = io::open_file(file_name);
+    auto file = io::open_file(file_name, io::open_mode::read_only);
     auto file_size = io::seek(file, 0, io::seek_mode::end);
     io::seek(file, 0, io::seek_mode::start);
     std::vector<std::uint8_t> output;
@@ -207,7 +207,7 @@ std::vector<std::uint8_t> read_modern_range_prealloc(const char* file_name)
 // Read an mmap'd file into a preallocated vector with exceptions
 std::vector<std::uint8_t> read_modern_mmap_prealloc(const char* file_name)
 {
-    auto file = io::posix::mmap_file::open(file_name);
+    auto file = io::posix::mmap_file{file_name, io::open_mode::read_only};
     std::vector<uint8_t> output(file.size());
     io::read(file, io::buffer(output));
     return output;
@@ -216,14 +216,14 @@ std::vector<std::uint8_t> read_modern_mmap_prealloc(const char* file_name)
 // Read an mmap'd file into a vector using a stream reader
 std::vector<std::uint8_t> read_modern_mmap_range(const char* file_name)
 {
-    auto file = io::posix::mmap_file::open(file_name);
+    auto file = io::posix::mmap_file{file_name, io::open_mode::read_only};
     return io::read(std::move(file));
 }
 
 // Read an mmap'd fine into a preallocated vector using a stream reader
 std::vector<std::uint8_t> read_modern_mmap_range_prealloc(const char* file_name)
 {
-    auto file = io::posix::mmap_file::open(file_name);
+    auto file = io::posix::mmap_file{file_name, io::open_mode::read_only};
     std::vector<std::uint8_t> output;
     output.reserve(file.size());
     io::rng::copy(io::read(std::move(file)), io::rng::back_inserter(output));

--- a/include/io/file.hpp
+++ b/include/io/file.hpp
@@ -17,15 +17,30 @@ namespace fs = io_std::filesystem;
 
 using file = posix::file;
 
-inline file open_file(const fs::path& path, std::error_code& ec) noexcept
+inline file open_file(const fs::path& path,
+                      open_mode mode,
+                      fs::perms create_perms,
+                      std::error_code& ec) noexcept
 {
-    return file::open(path, ec);
+    file f;
+    f.open(path, mode, create_perms, ec);
+    return f;
 }
 
-inline file open_file(const fs::path& path)
+
+inline file open_file(const fs::path& path,
+                      open_mode mode,
+                      std::error_code& ec) noexcept
+{
+    return open_file(path, mode, default_creation_perms, ec);
+}
+
+inline file open_file(const fs::path& path,
+                      open_mode mode,
+                      fs::perms perms = default_creation_perms)
 {
     std::error_code ec{};
-    auto f = open_file(path, ec);
+    auto f = open_file(path, mode, perms, ec);
     if (ec) {
         throw std::system_error{ec};
     }

--- a/include/io/open_mode.hpp
+++ b/include/io/open_mode.hpp
@@ -1,0 +1,76 @@
+
+#ifndef IO_OPEN_MODE_HPP
+#define IO_OPEN_MODE_HPP
+
+namespace io {
+
+/// Flags to specify modes when opening a file
+enum class open_mode {
+    /// The file will be opened for reading only.
+    /// Attempting to write to the file will result in a runtime error.
+    /// It is an error to set this flag and `write_only` at the same time.
+    /// This is equivalent to the Posix mode `O_RDONLY`
+    read_only = 1,
+    /// The file will be opened for writing only.
+    /// Attempting to read from the file will result in a runtime error.
+    /// It is an error to set this flag and `read_only` at the same time.
+    /// This is equivalent to the Posix mode `O_WRONLY`
+    write_only = 2,
+    /// Open the file for both reading and writing
+    /// This is equivalent to the Posix mode `O_RDWR`
+    read_write = 4,
+    /// If the file exists, truncate it to zero size when opening
+    /// This is equivalent to the Posix mode `O_TRUNC`
+    truncate = 8,
+    /// Always write to the end of the file, regardless of the current position
+    /// of the stream cursor
+    /// This is equivalent to the Posix mode `O_APPEND`
+    append = 16,
+    /// Create the file if it does not exist
+    /// If this flag is *not* specified, a runtime error will occur if the file
+    /// does not exist.
+    /// This is equivalent to the Posix mode `O_CREAT`
+    create = 32,
+    /// Always create the file
+    /// If this flag is specified, a runtime error will occur if the file
+    /// already exists.
+    /// This is equivalent to the Posix mode `O_CREAT | O_EXCL`
+    always_create = 64
+};
+
+/// Bitwise `and` operation for `open_mode`
+constexpr open_mode operator&(open_mode lhs, open_mode rhs)
+{
+    using u = std::underlying_type_t<open_mode>;
+    return static_cast<open_mode>(static_cast<u>(lhs) & static_cast<u>(rhs));
+}
+
+/// Bitwise `or` operation for `open_mode`
+constexpr open_mode operator|(open_mode lhs, open_mode rhs)
+{
+    using u = std::underlying_type_t<open_mode>;
+    return static_cast<open_mode>(static_cast<u>(lhs) | static_cast<u>(rhs));
+}
+
+/// Bitwise `and` assignment operator for `open_mode`
+constexpr open_mode& operator&=(open_mode& lhs, open_mode rhs)
+{
+    lhs = lhs & rhs;
+    return lhs;
+}
+
+/// Bitwise `or` assignment operator for `open_mode`
+constexpr open_mode& operator|=(open_mode& lhs, open_mode rhs)
+{
+    lhs = lhs | rhs;
+    return lhs;
+}
+
+/// Default permissions when creating a new file, if not overridden
+constexpr io_std::filesystem::perms default_creation_perms =
+    io_std::filesystem::perms::owner_read |
+    io_std::filesystem::perms::owner_write;
+
+}
+
+#endif // IO_OPEN_MODE_HPP

--- a/include/io/posix/file.hpp
+++ b/include/io/posix/file.hpp
@@ -257,7 +257,7 @@ public:
         return bytes_written;
     }
 
-    std::size_t write_some(const io::mutable_buffer& cb, std::error_code& ec)
+    std::size_t write_some(const io::const_buffer& cb, std::error_code& ec)
     {
         ec.clear();
 

--- a/include/io/posix/file.hpp
+++ b/include/io/posix/file.hpp
@@ -65,20 +65,6 @@ public:
     using offset_type = ::off_t;
     using native_handle_type = int;
 
-    static file open(const io_std::filesystem::path& path, std::error_code& ec) noexcept
-    {
-        ec.clear();
-        errno = 0;
-        file_descriptor_handle fd{::open(path.c_str(), O_RDWR | O_CREAT, 0600), true};
-
-        if (fd.get() < 0) {
-            ec.assign(errno, std::system_category());
-            return posix::file{};
-        }
-
-        return posix::file{std::move(fd)};
-    }
-
     file() = default;
 
     explicit file(posix::file_descriptor_handle fd) noexcept

--- a/include/io/posix/file.hpp
+++ b/include/io/posix/file.hpp
@@ -3,9 +3,12 @@
 #define IO_POSIX_FILE_HPP
 
 #include <io/io_std/filesystem.hpp>
-#include <io/posix/descriptor_stream.hpp>
+#include <io/posix/file_descriptor_handle.hpp>
 
 #include <fcntl.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <unistd.h>
 
 namespace io {
 namespace posix {
@@ -28,8 +31,10 @@ constexpr int seek_mode_to_whence_arg(seek_mode m)
 } // end namespace detail
 
 
-struct file : descriptor_stream {
+class file {
+public:
     using offset_type = ::off_t;
+    using native_handle_type = int;
 
     static file open(const io_std::filesystem::path& path, std::error_code& ec) noexcept
     {
@@ -48,7 +53,145 @@ struct file : descriptor_stream {
     file() = default;
 
     explicit file(posix::file_descriptor_handle fd) noexcept
-            : descriptor_stream{std::move(fd)} {}
+    native_handle_type native_handle() const noexcept { return fd_.get(); }
+
+    // SyncReadStream implementation
+
+    template <typename MutBufSeq,
+            CONCEPT_REQUIRES_(MutableBufferSequence<MutBufSeq>())>
+    std::size_t read_some(const MutBufSeq& mb)
+    {
+        std::error_code ec;
+        auto sz = this->read_some(mb, ec);
+        if (ec) {
+            throw std::system_error{ec};
+        }
+        return sz;
+    }
+
+    template <typename MutBufSeq,
+            CONCEPT_REQUIRES_(MutableBufferSequence<MutBufSeq>())>
+    std::size_t read_some(const MutBufSeq& mb, std::error_code& ec) noexcept
+    {
+        ec.clear();
+
+        if (buffer_size(mb) == 0) {
+            return 0;
+        }
+
+        // Prepare buffers
+        constexpr int max_iovec = 16; //?
+        std::array<::iovec, max_iovec> io_vecs{};
+
+        int i = 0;
+        for (auto it = buffer_sequence_begin(mb);
+             it != buffer_sequence_end(mb); ++it) {
+            io_vecs[i].iov_base = it->data();
+            io_vecs[i].iov_len = it->size();
+            if (++i == max_iovec) {
+                break;
+            }
+        }
+
+        auto bytes = ::readv(native_handle(), io_vecs.data(), i);
+
+        if (bytes == 0) {
+            ec = stream_errc::eof;
+        }
+        else if (bytes < 0) {
+            ec.assign(errno, std::system_category());
+        }
+        else {
+            ec.clear();
+        }
+
+        return bytes;
+    }
+
+    std::size_t read_some(const io::mutable_buffer& mb, std::error_code& ec)
+    {
+        ec.clear();
+
+        if (mb.size() == 0) {
+            return 0;
+        }
+
+        auto bytes_read = ::read(native_handle(), mb.data(), mb.size());
+
+        if (bytes_read == 0) {
+            ec = stream_errc::eof;
+        }
+        else if (bytes_read < 0) {
+            ec.assign(errno, std::system_category());
+        }
+
+        return bytes_read;
+    }
+
+    // SyncWriteStream implementation
+
+    template <typename ConstBufSeq,
+            CONCEPT_REQUIRES_(ConstBufferSequence<ConstBufSeq>())>
+    std::size_t write_some(ConstBufSeq& cb)
+    {
+        std::error_code ec;
+        auto sz = write_some(cb, ec);
+
+        if (ec) {
+            throw std::system_error{ec};
+        }
+
+        return sz;
+    }
+
+    template <typename ConstBufSeq,
+            CONCEPT_REQUIRES_(ConstBufferSequence<ConstBufSeq>())>
+    std::size_t write_some(ConstBufSeq& cb, std::error_code& ec) noexcept
+    {
+        if (io::buffer_size(cb) == 0) {
+            ec.clear();
+            return 0;
+        }
+
+        // Prepare buffers
+        constexpr int max_iovec = 16; //?
+        std::array<::iovec, max_iovec> io_vecs{};
+
+        int i = 0;
+        for (auto it = buffer_sequence_begin(cb);
+             it != buffer_sequence_end(cb); ++it) {
+            io_vecs[i].iov_base = it->data();
+            io_vecs[i].iov_len = it->size();
+            if (++i == max_iovec) {
+                break;
+            }
+        }
+
+        auto bytes_written = ::writev(native_handle(), io_vecs.data(), i);
+
+        if (bytes_written < 0) {
+            ec.assign(errno, std::system_category());
+        }
+
+        return bytes_written;
+    }
+
+    std::size_t write_some(const io::mutable_buffer& cb, std::error_code& ec)
+    {
+        ec.clear();
+
+        if (cb.size() == 0) {
+            return 0;
+        }
+
+        auto bytes_written = ::write(native_handle(), cb.data(), cb.size());
+
+        if (bytes_written < 0) {
+            ec.assign(errno, std::system_category());
+        }
+
+        return bytes_written;
+    }
 
     offset_type seek(offset_type offset, seek_mode from)
     {
@@ -92,6 +235,9 @@ struct file : descriptor_stream {
             throw std::system_error{ec};
         }
     }
+
+private:
+    file_descriptor_handle fd_{};
 };
 
 static_assert(SeekableStream<posix::file>(),

--- a/include/io/posix/file_descriptor_handle.hpp
+++ b/include/io/posix/file_descriptor_handle.hpp
@@ -28,6 +28,15 @@ struct file_descriptor_handle {
         other.delete_ = false;
     }
 
+    file_descriptor_handle& operator=(file_descriptor_handle&& other) noexcept
+    {
+        if (&other != this) {
+            std::swap(fd_, other.fd_);
+            std::swap(delete_, other.delete_);
+        }
+        return *this;
+    }
+
     /// Destroy the `file_descriptor_handle`
     /// If the underlying fd is owned, this will call ::close()
     ~file_descriptor_handle() noexcept

--- a/include/io/posix/file_descriptor_handle.hpp
+++ b/include/io/posix/file_descriptor_handle.hpp
@@ -54,6 +54,19 @@ struct file_descriptor_handle {
     /// Return the value of the fd
     int get() const noexcept { return fd_; }
 
+    /// Manually close the file descriptor
+    void close(std::error_code& ec) noexcept
+    {
+        ec.clear();
+        errno = 0;
+        if (::close(fd_) == 0) {
+            fd_ = -1;
+            delete_ = false;
+        } else {
+            ec.assign(errno, std::system_category());
+        }
+    }
+
 private:
     int fd_ = -1;
     bool delete_ = false;

--- a/include/io/posix/mmap_file.hpp
+++ b/include/io/posix/mmap_file.hpp
@@ -105,45 +105,6 @@ class mmap_file : public io::detail::memory_stream_impl<mmap_file, ::off_t> {
 public:
     using size_type = ::off_t;
 
-    static mmap_file open(const io_std::filesystem::path& path)
-    {
-        std::error_code ec;
-        auto file = mmap_file::open(path, ec);
-        if (ec) {
-            throw std::system_error{ec};
-        }
-        return file;
-    }
-
-    static mmap_file open(const io_std::filesystem::path& path,
-                          std::error_code& ec)
-    {
-        ec.clear();
-        errno = 0;
-
-        // First, try to open the file
-        file_descriptor_handle fd{::open(path.c_str(), O_RDWR | O_CREAT, 0600),
-                                  true};
-        if (fd.get() < 0) {
-            ec.assign(errno, std::system_category());
-            return mmap_file{};
-        }
-
-        // Seek to the end to find the size
-        offset_type size = ::lseek(fd.get(), 0, SEEK_END);
-        if (size == -1) {
-            ec.assign(errno, std::system_category());
-            return mmap_file{};
-        }
-
-        auto mmap = detail::mmap_handle::create(fd, size, ec);
-        if (ec) {
-            return mmap_file{};
-        }
-
-        return mmap_file{std::move(mmap)};
-    }
-
     mmap_file() = default;
 
     mmap_file(const io_std::filesystem::path& path,

--- a/include/io/posix/mmap_file.hpp
+++ b/include/io/posix/mmap_file.hpp
@@ -134,13 +134,13 @@ public:
         errno = 0;
 
         // First, try to open the file
-        file_descriptor_handle new_fd{::open(path.c_str(),
-                                             detail::open_mode_to_posix_mode(mode),
-                                             static_cast<::mode_t>(create_perms))};
-        if (new_fd.get() < 0) {
+        int raw_fd = ::open(path.c_str(), detail::open_mode_to_posix_mode(mode),
+                            static_cast<::mode_t>(create_perms));
+        if (raw_fd < 0) {
             ec.assign(errno, std::system_category());
             return;
         }
+        file_descriptor_handle new_fd{raw_fd};
 
         // Now seek to the end to find the file size
         offset_type size = ::lseek(new_fd.get(), 0, SEEK_END);

--- a/include/io/posix/mmap_stream_reader.hpp
+++ b/include/io/posix/mmap_stream_reader.hpp
@@ -3,6 +3,7 @@
 #define IO_POSIX_MMAP_STREAM_READER_HPP
 
 #include <io/posix/mmap_file.hpp>
+#include <io/stream_reader.hpp>
 
 namespace io {
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,4 +14,4 @@ add_executable(test-modern-io
 
 add_dependencies(test-modern-io range-v3)
 target_include_directories(test-modern-io PRIVATE ${RANGE_INCLUDE_DIR})
-target_link_libraries(test-modern-io Threads::Threads)
+target_link_libraries(test-modern-io Threads::Threads ${MODERN_IO_FILESYSTEM_LIBRARY})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(test-modern-io
     basic_test.cpp
     buffer_copy_test.cpp
     catch_main.cpp
+    file_test.cpp
     read_until_test.cpp
     string_stream_test.cpp
     string_view_stream_test.cpp

--- a/test/file_test.cpp
+++ b/test/file_test.cpp
@@ -1,0 +1,78 @@
+
+#include "catch.hpp"
+
+#include <io/file.hpp>
+#include <io/read.hpp>
+#include <io/posix/mmap_file.hpp>
+#include <io/io_std/string_view.hpp>
+
+#include <cstdio>
+
+// FIXME: This entire file needs to be much, much better
+
+const io_std::string_view test_file_contents =
+    "The quick brown fox jumps over the lazy dog";
+
+constexpr char test_file_name[] = "io_test_file.txt";
+
+template <typename File>
+void test_read(File&& file)
+{
+    std::string contents;
+    REQUIRE_NOTHROW(io::read_all(file, io::dynamic_buffer(contents)));
+
+    REQUIRE(contents == test_file_contents);
+}
+
+template <typename File>
+void test_write(File&& file)
+{
+    REQUIRE_NOTHROW(io::write(file, io::buffer(test_file_contents)));
+
+    FILE* in_file = std::fopen(test_file_name, "rb");
+    std::string read_buf(test_file_contents.size(), '\0');
+    std::fread(&*read_buf.begin(), 1, test_file_contents.size(), in_file);
+
+    REQUIRE(test_file_contents == read_buf);
+
+    std::fclose(in_file);
+}
+
+TEST_CASE("Files reads work as expected", "[file]")
+{
+    // Prepare a test file.
+    FILE* out_file = std::fopen(test_file_name, "wb");
+    if (!out_file) {
+        throw std::system_error{errno, std::generic_category()};
+    }
+
+    std::size_t bytes_written = std::fwrite(test_file_contents.data(), sizeof(char),
+                                            test_file_contents.size(), out_file);
+    if (bytes_written != test_file_contents.size()) {
+        fclose(out_file);
+        throw std::system_error{errno, std::generic_category()};
+    }
+    std::fclose(out_file);
+
+    SECTION("io::file can read properly") {
+        io::file file{test_file_name, io::open_mode::read_only};
+        test_read(file);
+    }
+
+    SECTION("io::posix::mmap_file can read properly") {
+        io::posix::mmap_file file{test_file_name, io::open_mode::read_only};
+        test_read(file);
+    }
+
+    std::remove(test_file_name);
+}
+
+TEST_CASE("File writes work as expected", "[file]")
+{
+    SECTION("io::file can write properly") {
+        io::file file{test_file_name, io::open_mode::write_only |
+                                      io::open_mode::always_create};
+        test_write(file);
+        std::remove(test_file_name);
+    }
+}

--- a/test/file_test.cpp
+++ b/test/file_test.cpp
@@ -21,7 +21,7 @@ void test_read(File&& file)
     std::string contents;
     REQUIRE_NOTHROW(io::read_all(file, io::dynamic_buffer(contents)));
 
-    REQUIRE(contents == test_file_contents);
+    REQUIRE((contents == test_file_contents));
 }
 
 template <typename File>


### PR DESCRIPTION
This series of commits as a selection of open mode flags (read, write, append etc), and allows you to pass them to either the constructor or an open() method of a file.

This effectively allows “reopening” a file (though the fd will not be reused), and also an exception-free path to opening and closing files.
